### PR TITLE
JWT_NOT_BEFORE_DELTA影响正常登录

### DIFF
--- a/webDemo/lockerapp/config.py
+++ b/webDemo/lockerapp/config.py
@@ -7,7 +7,6 @@ class Config(object):
     SECRET_KEY = 'this is blank guo'
     JWT_AUTH_URL_RULE = '/login'
     JWT_EXPIRATION_DELTA = datetime.timedelta(weeks=4)
-    JWT_NOT_BEFORE_DELTA = datetime.timedelta(weeks=1)
     pass
 
 class prodConfig(Config):


### PR DESCRIPTION
试过app登录了，JWT_NOT_BEFORE_DELTA 应该是在 这段时间之后token才起作用，按此设置，一周后才有用，，，影响正常登录，删掉即可